### PR TITLE
removing restoreCtti arg, every structuring process will download ctti

### DIFF
--- a/arm-templates/azuredeploy-ctm.json
+++ b/arm-templates/azuredeploy-ctm.json
@@ -858,8 +858,7 @@
               "image": "[variables('structuringImageFullName')]",
               "command": [
                 "dotnet",
-                "ClinicalTrialsStructuring.dll",
-				        "restoreCttiDb"
+                "ClinicalTrialsStructuring.dll"
               ],
               "environmentVariables": [
                 {


### PR DESCRIPTION
unless told otherwise by skipRestoreCtti